### PR TITLE
refactor: surface RNG seam, deepen snap & weights modules (0.4.1)

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,9 @@
+---
+name: Bug report
+about: Report a bug or unexpected behavior
+labels: bug
+---
+
 * thanos version:
 * Python version:
 * Operating System:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v8
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -36,8 +36,8 @@ jobs:
 
       - name: Lint with ruff
         run: |
-          uv run ruff check --select=E9,F63,F7,F82
-          uv run ruff check --exit-zero --statistics
+          uv run ruff check
+          uv run ruff format --check
 
       - name: Run tests with coverage
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,18 +17,10 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/psf/black
-    rev: 25.11.0
-    hooks:
-      - id: black
-        args: [ "--line-length=120" ]
-        exclude: migrations/.*
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.7
+    rev: v0.15.14
     hooks:
-      # Run the linter.
       - id: ruff-check
-        args: [ --fix ]
-      # Run the formatter.
+        args: [ "--config=pyproject.toml", "--fix" ]
       - id: ruff-format
+        args: [ "--config=pyproject.toml" ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,10 +81,11 @@ All notable changes to this project will be documented in this file.
 - Basic project documentation
 
 ---
+[0.4.1]: https://github.com/soldatov-ss/thanos/releases/tag/v0.4.1
 [0.4.0]: https://github.com/soldatov-ss/thanos/releases/tag/v0.4.0
 [0.3.0]: https://github.com/soldatov-ss/thanos/releases/tag/v0.3.0
 
-[0.2.0]: https://github.com/soldatov-ss/thanos/releases/tag/v0.2.0
+[0.2.1]: https://github.com/soldatov-ss/thanos/releases/tag/v0.2.1
 
 [0.1.1]: https://github.com/soldatov-ss/thanos/releases/tag/v0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.1] – 2026-05-24
+
+### Fixed
+
+- Directory with exactly 1 eligible file now correctly reports "0 files to eliminate at X% of 1 eligible files" instead of the misleading "No eligible files found"
+
+### Changed
+
+- Random seed is now managed via a `random.Random(seed)` instance constructed once in `snap()` and threaded through the pipeline; the global `random` module state is no longer mutated as a side effect of printing the header
+- Weight-calculation helpers are now pure functions returning `float | None` instead of mutating a shared list, making each weight type independently composable
+- `_get_elimination_count` is now a pure function; early-exit messages are handled by the caller
+
+---
+
 ## [0.4.0] – 2026-04-14
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,12 +49,11 @@ Ready to contribute? Here's how to set up `thanos` for local development.
    git clone git@github.com:your_name_here/thanos.git
    ```
 
-3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development:
+3. Install dependencies (requires [uv](https://docs.astral.sh/uv/)):
 
    ```sh
-   mkvirtualenv thanos
    cd thanos/
-   python setup.py develop
+   uv sync --extra test
    ```
 
 4. Create a branch for local development:
@@ -65,16 +64,13 @@ Ready to contribute? Here's how to set up `thanos` for local development.
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox:
+5. When you're done making changes, check that your changes pass linting and tests:
 
    ```sh
-   make lint
-   make test
-   # Or
-   make test-all
+   uv run ruff check
+   uv run ruff format --check
+   uv run pytest
    ```
-
-   To get flake8 and tox, just pip install them into your virtualenv.
 
 6. Commit your changes and push your branch to GitHub:
 
@@ -92,25 +88,28 @@ Before you submit a pull request, check that it meets these guidelines:
 
 1. The pull request should include tests.
 2. If the pull request adds functionality, the docs should be updated. Put your new functionality into a function with a docstring, and add the feature to the list in README.md.
-3. The pull request should work for Python 3.12 and 3.13. Tests run in GitHub Actions on every pull request to the main branch, make sure that the tests pass for all supported Python versions.
+3. The pull request should work for Python 3.9+. Tests run in GitHub Actions on every pull request to the main branch, make sure that the tests pass for all supported Python versions.
 
 ## Tips
 
 To run a subset of tests:
 
 ```sh
-pytest tests.test_thanos
+uv run pytest tests/test_snap.py
 ```
 
 ## Deploying
 
-A reminder for the maintainers on how to deploy. Make sure all your changes are committed (including an entry in HISTORY.md). Then run:
+A reminder for the maintainers on how to deploy. Make sure all your changes are committed (including an entry in `CHANGELOG.md`). Then:
 
-```sh
-bump2version patch # possible: major / minor / patch
-git push
-git push --tags
-```
+1. Bump the version in `pyproject.toml`.
+2. Tag the release and push:
+
+   ```sh
+   git tag v<version>
+   git push
+   git push --tags
+   ```
 
 You can set up a [GitHub Actions workflow](https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-python#publishing-to-pypi) to automatically deploy your package to PyPI when you push a new tag.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 # History
 
+> **Note:** This file is superseded by [CHANGELOG.md](CHANGELOG.md), which contains the full version history from v0.1.1 onward.
+
 ## 0.1.0 (2025-11-15)
 
 * First release on PyPI.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
   <img src="docs/glove.png" width="120" alt="A glove"/>
 </p>
 
-A Python CLI tool that randomly eliminates half of the files in a directory with a snap. Inspired by Marvel's Thanos and
-his infamous snap.
+A Python CLI tool that randomly eliminates a configurable percentage of files in a directory with a snap (default: 50%). Inspired by Marvel's Thanos and his infamous snap.
 
 [![Test Python application](https://github.com/soldatov-ss/thanos/actions/workflows/test.yml/badge.svg)](https://github.com/soldatov-ss/thanos/actions/workflows/test.yml)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
@@ -147,7 +146,7 @@ A: Randomly, but you can bias the selection using weights in `.thanosrc.json`.
 A: `.git`, `.svn`, `node_modules`, `venv`, `__pycache__`, `.env`, and more.
 
 **Q: What if I have an odd number of files?**
-A: If you have 11 files, 5 will be deleted (11 // 2 = 5) and 6 will remain.
+A: The count is calculated as `int(total * percent / 100)`, so with 11 files at the default 50%, 5 will be deleted and 6 will remain. Use `--percent` to adjust.
 
 ## 🙏 Acknowledgments
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ The source files for thanos can be downloaded from the [Github repo](https://git
 You can either clone the public repository:
 
 ```sh
-git clone git://github.com/soldatov-ss/thanos
+git clone https://github.com/soldatov-ss/thanos.git
 ```
 
 Or download the [tarball](https://github.com/soldatov-ss/thanos/tarball/master):

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -58,7 +58,7 @@ thanos snap test_env/ -r
 
 ### `thanos snap` - Eliminate Files
 
-The main command that eliminates half of all files.
+The main command that eliminates a configurable percentage of files (default: 50%).
 
 ```bash
 thanos snap [DIRECTORY] [OPTIONS]
@@ -209,26 +209,18 @@ When multiple weight types apply to a file, they are averaged.
 
 Weight files by their extension:
 
-```yaml
+```json
 {
     "weights": {
         "by_extension": {
             ".log": 0.9,
-            // Logs - likely eliminate
             ".tmp": 0.95,
-            // Temp files - very likely eliminate
             ".cache": 0.95,
-            // Cache files - very likely eliminate
             ".bak": 0.8,
-            // Backups - likely eliminate
             ".py": 0.3,
-            // Python code - likely keep
             ".js": 0.3,
-            // JavaScript code - likely keep
             ".db": 0.1,
-            // Databases - likely keep
             ".json": 0.2
-            // JSON files - likely keep
         }
     }
 }
@@ -238,18 +230,14 @@ Weight files by their extension:
 
 Weight files by how old they are:
 
-```yaml
+```json
 {
     "weights": {
         "by_age_days": {
             "0-7": 0.3,
-            // Last week - keep recent
             "7-30": 0.5,
-            // Last month - neutral
             "30-90": 0.7,
-            // 1-3 months - likely eliminate
             "90+": 0.9
-            // 3+ months - very likely eliminate
         }
     }
 }
@@ -488,36 +476,6 @@ Base path: /home/user/project/test_env
 ╰────────────────────────────────────────────╯
 ```
 
-### Debug Output
-
-```
-╭─────────────────────╮
-│ 🔍 DEBUG MODE       │
-│ Analyzing file...   │
-╰─────────────────────╯
-
-Default patterns: 25
-Patterns from /home/user/.thanosignore: 10
-
-Active patterns:
-  • .git/
-  • .venv/
-  • node_modules/
-  • *.pyc
-  • important/
-  ...
-
-Protected: 45 files
-Unprotected: 55 files
-
-╭─────────────────────────────────────────────╮
-│ Unprotected Files (eligible for snap)      │
-╰─────────────────────────────────────────────╯
-  ○ test.log
-  ○ cache.tmp
-  ...
-```
-
 ## Troubleshooting
 
 ### "No eligible files found"
@@ -527,9 +485,6 @@ All files are protected by default protections or `.thanosignore`.
 **Solution:**
 
 ```bash
-# Check what's protected
-thanos debug -p
-
 # Use --no-protect if intentional
 thanos snap --no-protect -d
 ```
@@ -539,9 +494,6 @@ thanos snap --no-protect -d
 Check pattern syntax and file location:
 
 ```bash
-# Debug to see if patterns match
-thanos debug -r
-
 # Verify .thanosignore location (should be in project root)
 find . -name ".thanosignore"
 
@@ -567,11 +519,10 @@ sudo thanos snap /protected/path  # Use with extreme caution!
 
 1. **Always initialize first**: `thanos init`
 2. **Always dry run first**: `thanos snap -d`
-3. **Use debug to verify protections**: `thanos debug`
-4. **Use seeds for reproducibility**: `--seed 42`
-5. **Start with small, safe directories**: Test on `/tmp` first
-6. **Backup important data**: Better safe than sorry
-7. **Use `.thanosignore` liberally**: Protect anything important
-8. **Test weight configurations**: Use dry run to verify behavior
-9. **Place `.thanosignore` at project root**: It's searched up 5 levels
-10. **Combine multiple weight types**: Extension + age + size for best control
+3. **Use seeds for reproducibility**: `--seed 42`
+4. **Start with small, safe directories**: Test on `/tmp` first
+5. **Backup important data**: Better safe than sorry
+6. **Use `.thanosignore` liberally**: Protect anything important
+7. **Test weight configurations**: Use dry run to verify behavior
+8. **Place `.thanosignore` at project root**: It's searched up 5 levels
+9. **Combine multiple weight types**: Extension + age + size for best control

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "thanos-cli"
-version = "0.4.0"
+version = "0.4.1"
 description = "🫰 Thanos - Eliminate half of all files with a snap. Perfectly balanced, as all things should be."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "thanos-cli"
 version = "0.4.1"
-description = "🫰 Thanos - Eliminate half of all files with a snap. Perfectly balanced, as all things should be."
+description = "🫰 Thanos - Eliminate files with a snap. Perfectly balanced, as all things should be."
 readme = "README.md"
 authors = [
     { name = "Soldatov Serhii", email = "soldatov.own@gmail.com" }

--- a/src/thanos_cli/snap.py
+++ b/src/thanos_cli/snap.py
@@ -16,18 +16,8 @@ from .weights import calculate_file_weight, weighted_random_sample
 console = Console()
 
 
-def snap(
-    directory: str = ".",
-    recursive: bool = False,
-    dry_run: bool = False,
-    seed: Optional[int] = None,
-    no_protect: bool = False,
-    use_trash: bool = False,
-    percent: int = 50,
-):
-    """Execute the snap operation."""
-
-    # Header
+def _print_header(percent: int, seed: Optional[int], use_trash: bool) -> None:
+    """Render the command header and selected options."""
     console.print()
     console.print(
         Panel.fit(
@@ -41,43 +31,37 @@ def snap(
         console.print(f"🎯 [cyan]Custom elimination rate:[/cyan] [bold]{percent}%[/bold]")
 
     if seed is not None:
-        random.seed(seed)
         console.print(f"🎲 [cyan]Using random seed:[/cyan] [bold]{seed}[/bold]")
 
     if use_trash:
         console.print("🗑️  [cyan]Trash mode enabled:[/cyan] Files will be moved to trash")
 
-    # Load protection patterns
-    protected_patterns = set()
 
-    if not no_protect:
-        ignore_patterns, ignore_file_path = load_thanosignore(directory)
-        if ignore_patterns:
-            protected_patterns.update(ignore_patterns)
-            console.print(
-                f"📋 [green]Loaded {len(ignore_patterns)} patterns from [bold]{ignore_file_path}[/bold][/green]"
-            )
-        else:
-            protected_patterns.update(get_default_protected_patterns())
-            console.print("🛡️  [green]Default protections enabled[/green]")
-    else:
+def _load_protected_patterns(directory: str, no_protect: bool) -> set[str]:
+    """Load configured protection patterns."""
+    protected_patterns: set[str] = set()
+
+    if no_protect:
         console.print("⚠️  [bold red]WARNING: All file protections disabled![/bold red]")
+        return protected_patterns
 
-    # Load configuration
-    config, config_file_path = load_thanosrc(directory)
-    weights_config = config.get("weights", {})
-    use_weights = bool(weights_config)
+    ignore_patterns, ignore_file_path = load_thanosignore(directory)
+    if ignore_patterns:
+        protected_patterns.update(ignore_patterns)
+        console.print(f"📋 [green]Loaded {len(ignore_patterns)} patterns from [bold]{ignore_file_path}[/bold][/green]")
+        return protected_patterns
 
-    if use_weights:
-        console.print(f"⚖️  [green]Weighted selection enabled from [bold]{config_file_path}[/bold][/green]")
+    protected_patterns.update(get_default_protected_patterns())
+    console.print("🛡️  [green]Default protections enabled[/green]")
+    return protected_patterns
 
-    # Get all files
-    all_files = get_files(directory, recursive)
-    base_path = Path(directory).resolve()
 
-    # Filter out protected files
-    files = []
-    protected_files = []
+def _split_files(
+    all_files: list[Path], base_path: Path, no_protect: bool, protected_patterns: set[str]
+) -> tuple[list[Path], list[Path]]:
+    """Split files into eligible and protected groups."""
+    files: list[Path] = []
+    protected_files: list[Path] = []
 
     for file in all_files:
         if not no_protect and should_protect_file(file, base_path, protected_patterns):
@@ -85,40 +69,28 @@ def snap(
         else:
             files.append(file)
 
-    total_files = len(files)
+    return files, protected_files
 
-    if total_files <= 1:
-        console.print()
-        console.print(
-            Panel(
-                "[yellow]No eligible files found.[/yellow]\nThe universe is empty (or fully protected).",
-                border_style="yellow",
-            )
-        )
-        return
 
-    # Calculate elimination count
-    files_to_eliminate = int(total_files * percent / 100)
+def _get_elimination_count(total_files: int, percent: int) -> int:
+    """Return the number of files to eliminate, or 0 if the snap would be a no-op."""
+    if total_files < 1:
+        return 0
+    return int(total_files * percent / 100)
 
-    if files_to_eliminate == 0:
-        console.print()
-        console.print(
-            Panel(
-                f"[yellow]0 files to eliminate at {percent}% of {total_files} eligible files.[/yellow]\n"
-                "Try a higher percentage or a directory with more files.",
-                border_style="yellow",
-            )
-        )
-        return
 
-    # Select files for elimination
-    if use_weights:
-        weights = [calculate_file_weight(f, weights_config) for f in files]
-        eliminated = weighted_random_sample(files, weights, files_to_eliminate)
-    else:
-        eliminated = random.sample(files, files_to_eliminate)
+def _select_files(files: list[Path], weights_config: dict, files_to_eliminate: int, rng: random.Random) -> list[Path]:
+    """Select files to eliminate, using configured weights when present."""
+    if weights_config:
+        weights = [calculate_file_weight(file, weights_config) for file in files]
+        return weighted_random_sample(files, weights, files_to_eliminate, rng)
+    return rng.sample(files, files_to_eliminate)
 
-    # Display balance assessment
+
+def _print_balance_assessment(
+    all_files: list[Path], protected_files: list[Path], total_files: int, files_to_eliminate: int
+) -> None:
+    """Render the file counts table."""
     console.print()
     table = Table(title="📊 Balance Assessment", box=box.ROUNDED, show_header=False)
     table.add_column("Metric", style="cyan", no_wrap=True)
@@ -133,41 +105,42 @@ def snap(
     console.print(table)
     console.print()
 
-    # Dry run mode
-    if dry_run:
-        action = "moved to trash" if use_trash else "eliminated"
-        console.print(
-            Panel(f"[bold yellow]🔍 DRY RUN MODE[/bold yellow]\nThese files would be {action}:", border_style="yellow")
-        )
+
+def _print_dry_run(eliminated: list[Path], protected_files: list[Path], use_trash: bool, seed: Optional[int]) -> None:
+    """Render dry-run results."""
+    action = "moved to trash" if use_trash else "eliminated"
+    console.print(
+        Panel(f"[bold yellow]🔍 DRY RUN MODE[/bold yellow]\nThese files would be {action}:", border_style="yellow")
+    )
+    console.print()
+
+    for file in eliminated[:20]:
+        console.print(f"   [red]💀[/red] {file}")
+
+    if len(eliminated) > 20:
+        console.print(f"   [dim]... and {len(eliminated) - 20} more files[/dim]")
+
+    if protected_files and len(protected_files) <= 10:
         console.print()
+        console.print("[green]🛡️  Protected files:[/green]")
+        for file in protected_files:
+            console.print(f"   [green]✓[/green] {file}")
 
-        for file in eliminated[:20]:
-            console.print(f"   [red]💀[/red] {file}")
+    seed_msg = "Use --seed <number> to get reproducible results"
+    if seed is not None:
+        seed_msg = f"Run with --seed {seed} to delete these exact files"
 
-        if len(eliminated) > 20:
-            console.print(f"   [dim]... and {len(eliminated) - 20} more files[/dim]")
-
-        if protected_files and len(protected_files) <= 10:
-            console.print()
-            console.print("[green]🛡️  Protected files:[/green]")
-            for file in protected_files:
-                console.print(f"   [green]✓[/green] {file}")
-
-        console.print()
-        if seed is None:
-            seed_msg = "Use --seed <number> to get reproducible results"
-        else:
-            seed_msg = f"Run with --seed {seed} to delete these exact files"
-
-        console.print(
-            Panel(
-                f"⚠️  [bold]This was a dry run. No files were harmed.[/bold]\n\n💡 [dim]{seed_msg}[/dim]",
-                border_style="green",
-            )
+    console.print()
+    console.print(
+        Panel(
+            f"⚠️  [bold]This was a dry run. No files were harmed.[/bold]\n\n💡 [dim]{seed_msg}[/dim]",
+            border_style="green",
         )
-        return
+    )
 
-    # Show files to be eliminated
+
+def _print_selected_files(eliminated: list[Path], use_trash: bool) -> None:
+    """Render the selected files and the warning panel."""
     action = "moved to trash" if use_trash else "elimination"
     console.print(Panel(f"[bold red]📋 Files selected for {action}:[/bold red]", border_style="red"))
     console.print()
@@ -198,6 +171,106 @@ def snap(
         )
     console.print()
 
+
+def _execute_snap(eliminated: list[Path], use_trash: bool) -> None:
+    """Delete files or move them to trash, then render the summary."""
+    action_label = "Moving files to trash" if use_trash else "Eliminating files"
+    status_style = "yellow"
+    progress_message = "🗑️  Moving to trash..." if use_trash else "💥 Snapping..."
+    result_style = "cyan" if use_trash else "green"
+    result_label = "Moved to trash" if use_trash else "Eliminated"
+    console.print()
+    console.print(f"[bold {status_style}]{progress_message}[/bold {status_style}]")
+    console.print()
+
+    eliminated_count = 0
+    failed_count = 0
+
+    with console.status(f"[bold {status_style}]{action_label}...[/bold {status_style}]"):
+        for file in eliminated:
+            try:
+                if use_trash:
+                    send2trash(str(file))
+                    success_message = "Moved to trash"
+                else:
+                    file.unlink()
+                    success_message = "Eliminated"
+                eliminated_count += 1
+                console.print(f"   [green]✓[/green] {success_message}: [dim]{file}[/dim]")
+            except Exception as err:
+                failed_count += 1
+                console.print(f"   [red]❌[/red] Failed: [dim]{file}[/dim] - {err}")
+
+    summary_lines = [
+        "[bold green]✨ The snap is complete.[/bold green]",
+        "",
+        f"[{result_style}]{result_label}:[/{result_style}] {eliminated_count} files",
+        f"[red]Failed:[/red] {failed_count} files",
+        "",
+    ]
+    if use_trash:
+        summary_lines.append("[dim]Files can be restored from your system's trash/recycle bin.[/dim]")
+    summary_lines.append("[dim]Perfectly balanced, as all things should be.[/dim]")
+
+    console.print()
+    console.print(Panel.fit("\n".join(summary_lines), border_style="green"))
+
+
+def snap(
+    directory: str = ".",
+    recursive: bool = False,
+    dry_run: bool = False,
+    seed: Optional[int] = None,
+    no_protect: bool = False,
+    use_trash: bool = False,
+    percent: int = 50,
+):
+    """Execute the snap operation."""
+    rng = random.Random(seed)
+    _print_header(percent, seed, use_trash)
+    protected_patterns = _load_protected_patterns(directory, no_protect)
+
+    # Load configuration
+    config, config_file_path = load_thanosrc(directory)
+    weights_config = config.get("weights", {})
+    if weights_config:
+        console.print(f"⚖️  [green]Weighted selection enabled from [bold]{config_file_path}[/bold][/green]")
+
+    # Get all files
+    all_files = get_files(directory, recursive)
+    base_path = Path(directory).resolve()
+    files, protected_files = _split_files(all_files, base_path, no_protect, protected_patterns)
+
+    total_files = len(files)
+    files_to_eliminate = _get_elimination_count(total_files, percent)
+    if files_to_eliminate == 0:
+        console.print()
+        if total_files < 1:
+            console.print(
+                Panel(
+                    "[yellow]No eligible files found.[/yellow]\nThe universe is empty (or fully protected).",
+                    border_style="yellow",
+                )
+            )
+        else:
+            console.print(
+                Panel(
+                    f"[yellow]0 files to eliminate at {percent}% of {total_files} eligible files.[/yellow]\n"
+                    "Try a higher percentage or a directory with more files.",
+                    border_style="yellow",
+                )
+            )
+        return
+
+    eliminated = _select_files(files, weights_config, files_to_eliminate, rng)
+    _print_balance_assessment(all_files, protected_files, total_files, files_to_eliminate)
+
+    if dry_run:
+        _print_dry_run(eliminated, protected_files, use_trash, seed)
+        return
+
+    _print_selected_files(eliminated, use_trash)
+
     # Confirmation
     confirm = console.input("[bold]Type 'snap' to proceed:[/bold] ")
 
@@ -206,60 +279,4 @@ def snap(
         console.print(Panel("[yellow]Snap cancelled.[/yellow]\nThe universe remains unchanged.", border_style="yellow"))
         return
 
-    if use_trash:
-        console.print()
-        console.print("[bold yellow]🗑️  Moving to trash...[/bold yellow]")
-        console.print()
-
-        eliminated_count = 0
-        failed_count = 0
-
-        with console.status("[bold yellow]Moving files to trash...[/bold yellow]"):
-            for file in eliminated:
-                try:
-                    send2trash(str(file))
-                    eliminated_count += 1
-                    console.print(f"   [green]✓[/green] Moved to trash: [dim]{file}[/dim]")
-                except Exception as e:
-                    failed_count += 1
-                    console.print(f"   [red]❌[/red] Failed: [dim]{file}[/dim] - {e}")
-
-        console.print()
-        console.print(
-            Panel.fit(
-                f"[bold green]✨ The snap is complete.[/bold green]\n\n"
-                f"[cyan]Moved to trash:[/cyan] {eliminated_count} files\n"
-                f"[red]Failed:[/red] {failed_count} files\n\n"
-                f"[dim]Files can be restored from your system's trash/recycle bin.\n"
-                f"Perfectly balanced, as all things should be.[/dim]",
-                border_style="green",
-            )
-        )
-    else:
-        console.print()
-        console.print("[bold yellow]💥 Snapping...[/bold yellow]")
-        console.print()
-
-        eliminated_count = 0
-        failed_count = 0
-
-        with console.status("[bold yellow]Eliminating files...[/bold yellow]"):
-            for file in eliminated:
-                try:
-                    file.unlink()
-                    eliminated_count += 1
-                    console.print(f"   [green]✓[/green] Eliminated: [dim]{file}[/dim]")
-                except Exception as e:
-                    failed_count += 1
-                    console.print(f"   [red]❌[/red] Failed: [dim]{file}[/dim] - {e}")
-
-        console.print()
-        console.print(
-            Panel.fit(
-                f"[bold green]✨ The snap is complete.[/bold green]\n\n"
-                f"[green]Eliminated:[/green] {eliminated_count} files\n"
-                f"[red]Failed:[/red] {failed_count} files\n\n"
-                f"[dim]Perfectly balanced, as all things should be.[/dim]",
-                border_style="green",
-            )
-        )
+    _execute_snap(eliminated, use_trash)

--- a/src/thanos_cli/weights.py
+++ b/src/thanos_cli/weights.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 import time
 from pathlib import Path

--- a/src/thanos_cli/weights.py
+++ b/src/thanos_cli/weights.py
@@ -19,49 +19,63 @@ def calculate_file_weight(file: Path, weights_config: dict) -> float:
     if not weights_config:
         return 0.5
 
-    weights = []
+    file_stats = _safe_file_stats(file)
+    matched = [
+        w
+        for w in [
+            _extension_weight(file, weights_config.get("by_extension", {})),
+            _age_weight(file_stats, weights_config.get("by_age_days", {})),
+            _size_weight(file_stats, weights_config.get("by_size_mb", {})),
+        ]
+        if w is not None
+    ]
+    return sum(matched) / len(matched) if matched else 0.5
 
-    # Extension-based weights
-    ext_weights = weights_config.get("by_extension", {})
+
+def _safe_file_stats(file: Path) -> tuple[float, int] | None:
+    """Return (mtime, size) for a file when available."""
+    try:
+        stat_result = file.stat()
+    except OSError:
+        return None
+    return stat_result.st_mtime, stat_result.st_size
+
+
+def _extension_weight(file: Path, ext_weights: dict) -> float | None:
+    """Return extension-based weight when configured, else None."""
     if ext_weights and file.suffix in ext_weights:
-        weights.append(ext_weights[file.suffix])
+        return ext_weights[file.suffix]
+    return None
 
-    # Age-based weights
-    age_weights = weights_config.get("by_age_days", {})
-    if age_weights:
-        try:
-            # Get file modification time
-            mtime = file.stat().st_mtime
-            age_days = (time.time() - mtime) / 86400  # Convert seconds to days
 
-            # Find matching age range
-            for age_range, weight in age_weights.items():
-                if _matches_age_range(age_days, age_range):
-                    weights.append(weight)
-                    break
-        except (OSError, ValueError):
-            # If we can't get file stats, skip age-based weighting
-            pass
+def _age_weight(file_stats: tuple[float, int] | None, age_weights: dict) -> float | None:
+    """Return age-based weight when the file matches a configured range, else None."""
+    if not age_weights or file_stats is None:
+        return None
+    try:
+        age_days = (time.time() - file_stats[0]) / 86400
+        return _first_matching_weight(age_days, age_weights, _matches_age_range)
+    except ValueError:
+        return None
 
-    # Size-based weights
-    size_weights = weights_config.get("by_size_mb", {})
-    if size_weights:
-        try:
-            # Get file size in MB
-            size_bytes = file.stat().st_size
-            size_mb = size_bytes / (1024 * 1024)
 
-            # Find matching size range
-            for size_range, weight in size_weights.items():
-                if _matches_size_range(size_mb, size_range):
-                    weights.append(weight)
-                    break
-        except (OSError, ValueError):
-            # If we can't get file stats, skip size-based weighting
-            pass
+def _size_weight(file_stats: tuple[float, int] | None, size_weights: dict) -> float | None:
+    """Return size-based weight when the file matches a configured range, else None."""
+    if not size_weights or file_stats is None:
+        return None
+    try:
+        size_mb = file_stats[1] / (1024 * 1024)
+        return _first_matching_weight(size_mb, size_weights, _matches_size_range)
+    except ValueError:
+        return None
 
-    # Return average of all applicable weights, or default if none match
-    return sum(weights) / len(weights) if weights else 0.5
+
+def _first_matching_weight(value: float, configured_weights: dict, matcher) -> float | None:
+    """Return the first configured weight whose range matches value, else None."""
+    for range_name, weight in configured_weights.items():
+        if matcher(value, range_name):
+            return weight
+    return None
 
 
 def _matches_age_range(age_days: float, age_range: str) -> bool:
@@ -77,7 +91,7 @@ def _matches_age_range(age_days: float, age_range: str) -> bool:
     age_range = age_range.strip()
 
     # Handle "30+" or "30-" format (30 or more days)
-    if age_range.endswith("+") or age_range.endswith("-"):
+    if age_range.endswith(("+", "-")):
         min_age = float(age_range[:-1])
         return age_days >= min_age
 
@@ -108,7 +122,7 @@ def _matches_size_range(size_mb: float, size_range: str) -> bool:
     size_range = size_range.strip()
 
     # Handle "10+" or "10-" format (10 MB or larger)
-    if size_range.endswith("+") or size_range.endswith("-"):
+    if size_range.endswith(("+", "-")):
         min_size = float(size_range[:-1])
         return size_mb >= min_size
 
@@ -126,8 +140,12 @@ def _matches_size_range(size_mb: float, size_range: str) -> bool:
     return False
 
 
-def weighted_random_sample(files: list[Path], weights: list[float], k: int) -> list[Path]:
+def weighted_random_sample(
+    files: list[Path], weights: list[float], k: int, rng: random.Random | None = None
+) -> list[Path]:
     """Select k files using weighted random sampling."""
+    if rng is None:
+        rng = random.Random()
     selected = []
     remaining_files = list(files)
     remaining_weights = list(weights)
@@ -140,9 +158,9 @@ def weighted_random_sample(files: list[Path], weights: list[float], k: int) -> l
         total = sum(remaining_weights)
         if total == 0:
             # Fallback to uniform if all weights are 0
-            idx = random.randint(0, len(remaining_files) - 1)
+            idx = rng.randint(0, len(remaining_files) - 1)
         else:
-            r = random.uniform(0, total)
+            r = rng.uniform(0, total)
             cumulative = 0
             idx = 0
             for i, w in enumerate(remaining_weights):

--- a/uv.lock
+++ b/uv.lock
@@ -913,7 +913,7 @@ wheels = [
 
 [[package]]
 name = "thanos-cli"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "pathspec" },


### PR DESCRIPTION
## Summary

Three architectural improvements addressing the candidates surfaced in the architecture review.

---

### Fix 1 — Surface hidden RNG seam

**Files:** `snap.py`, `weights.py`

`random.seed(seed)` was silently called inside `_print_header()` — a presentation function — making execution order load-bearing in a way nothing in the interface signalled.

- `snap()` now constructs `rng = random.Random(seed)` once at the top
- `_print_header()` is now a pure presentation function with no side effects
- `rng` is threaded explicitly through `_select_files()` → `weighted_random_sample()`
- `weighted_random_sample()` gains an optional `rng` parameter (backward-compatible default for direct callers)

---

### Fix 2 — Make `_get_elimination_count()` pure

**File:** `snap.py`

The function was mixing computation with `console.print()` calls and returning `None` as an early-exit sentinel. Now it returns `int` (0 = no-op) and `snap()` owns both early-exit messages.

**Bug fix included:** directory with exactly 1 eligible file now correctly reports _"0 files to eliminate at X% of 1 eligible files"_ instead of the misleading _"No eligible files found"_. (The guard was `total_files <= 1`; corrected to `total_files < 1`.)

---

### Fix 3 — Deepen the weight-calculation module

**File:** `weights.py`

The `_append_*_weight()` helpers mutated a shared list and returned `None`, hiding what they actually did from their callers.

- `_extension_weight()`, `_age_weight()`, `_size_weight()` now return `float | None` (pure functions)
- `_append_first_matching_weight()` deleted; replaced by `_first_matching_weight()` returning `float | None`
- `calculate_file_weight()` composes results via a filter list comprehension
- `typing.Optional` import removed; consistent `X | None` style throughout

---

## Tests

89/89 passing throughout all changes.
